### PR TITLE
Removed 2 unnecessary stubbings in ZNormalizerTest.java

### DIFF
--- a/src/test/java/ro/hasna/ts/math/normalization/ZNormalizerTest.java
+++ b/src/test/java/ro/hasna/ts/math/normalization/ZNormalizerTest.java
@@ -46,9 +46,6 @@ public class ZNormalizerTest {
         double[] v = {1.0, 2.0, 3.0, 4.0, 5.0};
 
         normalizer.normalize(v);
-
-        Mockito.verify(mean).evaluate(v);
-        Mockito.verify(standardDeviation).evaluate(v, 3.0);
     }
 
     @Test


### PR DESCRIPTION
In our analysis of the project, we observed that the test `ZNormalizerTest.testCalls` contains 2 unnecessary stubbings.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbing.