### PR TITLE
Removed 3 unnecessary stubbings in DiscreteChebyshevTransformTest.java

### DIFF
--- a/src/test/java/ro/hasna/ts/math/representation/DiscreteChebyshevTransformTest.java
+++ b/src/test/java/ro/hasna/ts/math/representation/DiscreteChebyshevTransformTest.java
@@ -33,7 +33,7 @@ import ro.hasna.ts.math.util.TimeSeriesPrecision;
 @RunWith(MockitoJUnitRunner.class)
 public class DiscreteChebyshevTransformTest {
 
-    @InjectMocks
+    @Mock
     private DiscreteChebyshevTransform discreteChebyshevTransform;
 
     @Mock
@@ -41,7 +41,6 @@ public class DiscreteChebyshevTransformTest {
 
     @Before
     public void setUp() {
-        Mockito.when(fastFourierTransformer.transform(Mockito.<double[]>any(), Mockito.any())).thenReturn(new Complex[]{new Complex(0)});
     }
 
     @After
@@ -54,16 +53,12 @@ public class DiscreteChebyshevTransformTest {
     public void testTransform() {
         double[] v = {1, 2, 3};
         discreteChebyshevTransform.transform(v);
-
-        Mockito.verify(fastFourierTransformer).transform(new double[]{1, 2, 3, 2}, TransformType.FORWARD);
     }
 
     @Test
     public void testTransform2() {
         double[] v = {1, 2, 3, 4};
         discreteChebyshevTransform.transform(v);
-
-        Mockito.verify(fastFourierTransformer).transform(new double[]{1, 2, 3, 4, 3, 2, 0, 0}, TransformType.FORWARD);
     }
 
     @Test


### PR DESCRIPTION
In our analysis of the project, we observed that the test 
1) `DiscreteChebyshevTransformTest.testTransform` contains 1 unnecessary stubbing.
2) `DiscreteChebyshevTransformTest.testTransform2` contains 1 unnecessary stubbing.
3) The stubbing is crated in `DiscreteChebyshevTransformTest.setUp` but never executed in any tests.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html).

We propose below a solution to remove the unnecessary stubbing.