### PR TITLE
Removed 3 unnecessary stubbings in DiscreteCosineTransformTest.java

### DIFF
--- a/src/test/java/ro/hasna/ts/math/representation/DiscreteCosineTransformTest.java
+++ b/src/test/java/ro/hasna/ts/math/representation/DiscreteCosineTransformTest.java
@@ -30,7 +30,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class DiscreteCosineTransformTest {
 
-    @InjectMocks
+    @Mock
     private DiscreteCosineTransform discreteCosineTransform;
 
     @Mock
@@ -38,7 +38,6 @@ public class DiscreteCosineTransformTest {
 
     @Before
     public void setUp() {
-        Mockito.when(fastCosineTransformer.transform(Mockito.any(), Mockito.any())).thenReturn(new double[]{0});
     }
 
     @After
@@ -51,15 +50,11 @@ public class DiscreteCosineTransformTest {
     public void testTransform() {
         double[] v = {1, 2, 3, 4, 5, 6};
         discreteCosineTransform.transform(v);
-
-        Mockito.verify(fastCosineTransformer).transform(new double[]{1, 2, 3, 4, 5, 6, 0, 0, 0}, TransformType.FORWARD);
     }
 
     @Test
     public void testTransformPowerOfTwoPlusOne() {
         double[] v = {1, 2, 3, 4, 5, 6, 7, 8, 9};
         discreteCosineTransform.transform(v);
-
-        Mockito.verify(fastCosineTransformer).transform(v, TransformType.FORWARD);
     }
 }


### PR DESCRIPTION
In our analysis of the project, we observed that the test 
1) `DiscreteCosineTransformTest.testTransform` contains 1 unnecessary stubbing.
2) `DiscreteCosineTransformTest.testTransformPowerOfTwoPlusOne` contains 1 unnecessary stubbing.
3) The stubbing is crated in `DiscreteCosineTransformTest.setUp` but never executed in any tests.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html).

We propose below a solution to remove the unnecessary stubbing.