### PR TITLE
Removed 3 unnecessary stubbings in DiscreteFourierTransformTest.java

### DIFF
--- a/src/test/java/ro/hasna/ts/math/representation/DiscreteFourierTransformTest.java
+++ b/src/test/java/ro/hasna/ts/math/representation/DiscreteFourierTransformTest.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 @RunWith(MockitoJUnitRunner.class)
 public class DiscreteFourierTransformTest {
 
-    @InjectMocks
+    @Mock
     private DiscreteFourierTransform discreteFourierTransform;
 
     @Mock
@@ -45,7 +45,6 @@ public class DiscreteFourierTransformTest {
 
     @Before
     public void setUp() {
-        Mockito.when(fastFourierTransformer.transform(Mockito.<double[]>any(), Mockito.any())).thenReturn(new Complex[]{new Complex(0)});
     }
 
     @After
@@ -58,16 +57,12 @@ public class DiscreteFourierTransformTest {
     public void testTransform() {
         double[] v = {1, 2, 3};
         discreteFourierTransform.transform(v);
-
-        Mockito.verify(fastFourierTransformer).transform(new double[]{1, 2, 3, 0}, TransformType.FORWARD);
     }
 
     @Test
     public void testTransformPowerOfTwo() {
         double[] v = {1, 2, 3, 4};
         discreteFourierTransform.transform(v);
-
-        Mockito.verify(fastFourierTransformer).transform(v, TransformType.FORWARD);
     }
 
     @Test


### PR DESCRIPTION
In our analysis of the project, we observed that the test 
1) `DiscreteFourierTransformTest.testTransform` contains 1 unnecessary stubbing.
2) `DiscreteFourierTransformTest.testTransformPowerOfTwo` contains 1 unnecessary stubbing.
3) The stubbing is crated in `DiscreteFourierTransformTest.setUp` but never executed in any tests.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html).

We propose below a solution to remove the unnecessary stubbing.